### PR TITLE
Add CLI for tracking per-user task progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore runtime task data
+tasks.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# codex-test
+# Codex Task Progress Tracker
+
+This repository provides a simple command line application for managing task progress per user. Tasks are stored locally in `tasks.json`.
+
+## Usage
+
+```
+python tasks.py add-user <username>
+python tasks.py add-task <username> <task description>
+python tasks.py update <username> <task index> <progress percentage>
+python tasks.py list <username>
+```
+
+Example:
+
+```
+python tasks.py add-user alice
+python tasks.py add-task alice "Write unit tests"
+python tasks.py update alice 0 40
+python tasks.py list alice
+```

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,90 @@
+import argparse
+import json
+from typing import Dict, List
+
+DATA_FILE = 'tasks.json'
+
+def load_data() -> Dict[str, List[dict]]:
+    try:
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+def save_data(data: Dict[str, List[dict]]):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+def add_user(data, username: str):
+    if username not in data:
+        data[username] = []
+        print(f"User '{username}' added")
+    else:
+        print(f"User '{username}' already exists")
+
+
+def add_task(data, username: str, task: str):
+    if username not in data:
+        print(f"User '{username}' does not exist")
+        return
+    data[username].append({'task': task, 'progress': 0})
+    print(f"Task added for {username}: {task}")
+
+
+def update_progress(data, username: str, index: int, progress: int):
+    if username not in data:
+        print(f"User '{username}' does not exist")
+        return
+    try:
+        data[username][index]['progress'] = progress
+        print(f"Updated task {index} for {username} to {progress}%")
+    except IndexError:
+        print(f"Task index {index} does not exist for {username}")
+
+
+def list_tasks(data, username: str):
+    if username not in data:
+        print(f"User '{username}' does not exist")
+        return
+    for i, t in enumerate(data[username]):
+        print(f"{i}: {t['task']} - {t['progress']}%")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Manage task progress per user')
+    subparsers = parser.add_subparsers(dest='command')
+
+    parser_user = subparsers.add_parser('add-user')
+    parser_user.add_argument('username')
+
+    parser_add = subparsers.add_parser('add-task')
+    parser_add.add_argument('username')
+    parser_add.add_argument('task')
+
+    parser_update = subparsers.add_parser('update')
+    parser_update.add_argument('username')
+    parser_update.add_argument('index', type=int)
+    parser_update.add_argument('progress', type=int)
+
+    parser_list = subparsers.add_parser('list')
+    parser_list.add_argument('username')
+
+    args = parser.parse_args()
+    data = load_data()
+
+    if args.command == 'add-user':
+        add_user(data, args.username)
+    elif args.command == 'add-task':
+        add_task(data, args.username, args.task)
+    elif args.command == 'update':
+        update_progress(data, args.username, args.index, args.progress)
+    elif args.command == 'list':
+        list_tasks(data, args.username)
+    else:
+        parser.print_help()
+        return
+
+    save_data(data)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a command-line tool `tasks.py` to manage task progress for each user
- document usage in `README.md`
- ignore runtime `tasks.json`

## Testing
- `python tasks.py --help`
- `python tasks.py add-user bob`
- `python tasks.py add-task bob 'Write documentation'`
- `python tasks.py list bob`
- `python tasks.py update bob 0 50`
